### PR TITLE
Add ability to inspect the TokenType

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -110,6 +110,13 @@ impl From<TokenType> for PyTokenType {
     }
 }
 
+#[pymethods]
+impl PyTokenType {
+    fn __str__(&self) -> String {
+        format!("{}", self.r#type)
+    }
+}
+
 #[pyclass(name = "AggModifier", module = "promql_parser")]
 #[derive(Debug, Clone)]
 pub struct PyAggModifier {


### PR DESCRIPTION
Not familiar with pyo3, if there is a better way to achieve this I'd like to hear :)

With this change you can write:

```
>>> f"agg: {promql_parser.parse('sum(rate(a[1m]))').op}"
'agg: sum'
```