### PR TITLE
Expose duration parsing/display functions

### DIFF
--- a/test_promql_parser.py
+++ b/test_promql_parser.py
@@ -11,3 +11,5 @@ print(parse('1 + 1'))
 print(parse('1 + 2/(3*1)').prettify())
 
 print(parse('+some_metric'))
+
+print(promql_parser.display_duration(promql_parser.parse_duration('4w4d2h59m120s')))


### PR DESCRIPTION
This adds the duration handling functions to the python api:

```
>>> promql_parser.parse_duration('4w4d2h59m120s')
datetime.timedelta(seconds=2775660)
>>> promql_parser.display_duration(promql_parser.parse_duration('4w4d2h59m120s'))
'32d3h1m'
```

Instead of introducing a type wrapper this exports directly into timedelta, which feels a bit more ergonomic on the python side