### PR TITLE
Fix bug where group modifier labels were dropped on to-string

### DIFF
--- a/promql_parser.pyi
+++ b/promql_parser.pyi
@@ -141,19 +141,22 @@ class BinModifier:
         If they are not this field is None.
       matching: on/ignoring on labels. Like a + b, no match modified is needed.
       return_bool: If a comparison operator, return 0/1 rather than filtering.
+      group_labels: Labels to retain from the low-cardinality side.
     """
 
     card: VectorMatchCardinality
     matching: Optional[LabelModifier]
     return_bool: bool
+    group_labels: Optional[List[str]]
 
-    def __init__(self, card: VectorMatchCardinality, return_bool: bool, matching: Optional[LabelModifier] = None) -> None:
+    def __init__(self, card: VectorMatchCardinality, return_bool: bool, matching: Optional[LabelModifier] = None, group_labels: Optional[List[str]] = None) -> None:
         """Create a new BinModifier.
 
         Args:
             card: The vector matching cardinality.
             return_bool: Whether to return bool values.
             matching: Optional label modifier for matching.
+            group_labels: Labels to retain from the low-cardinality side.
         """
         ...
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -229,21 +229,29 @@ impl PyBinaryExpr {
             modifier,
         } = expr;
         let py_modifier = match modifier {
-            Some(modifier) => Some(PyBinModifier {
-                card: modifier.card.into(),
-                matching: match modifier.matching {
-                    Some(LabelModifier::Include(labels)) => Some(PyLabelModifier {
-                        r#type: PyLabelModifierType::Include,
-                        labels: labels.labels,
-                    }),
-                    Some(LabelModifier::Exclude(labels)) => Some(PyLabelModifier {
-                        r#type: PyLabelModifierType::Exclude,
-                        labels: labels.labels,
-                    }),
-                    None => None,
-                },
-                return_bool: modifier.return_bool,
-            }),
+            Some(modifier) => {
+                let group_labels = match modifier.card {
+                    VectorMatchCardinality::ManyToOne(ref labels) => Some(labels.labels.clone()),
+                    VectorMatchCardinality::OneToMany(ref labels) => Some(labels.labels.clone()),
+                    _ => None,
+                };
+                Some(PyBinModifier {
+                    card: modifier.card.into(),
+                    matching: match modifier.matching {
+                        Some(LabelModifier::Include(labels)) => Some(PyLabelModifier {
+                            r#type: PyLabelModifierType::Include,
+                            labels: labels.labels,
+                        }),
+                        Some(LabelModifier::Exclude(labels)) => Some(PyLabelModifier {
+                            r#type: PyLabelModifierType::Exclude,
+                            labels: labels.labels,
+                        }),
+                        None => None,
+                    },
+                    return_bool: modifier.return_bool,
+                    group_labels,
+                })
+            }
             None => None,
         };
         let initializer = PyClassInitializer::from(parent).add_subclass(PyBinaryExpr {
@@ -282,21 +290,25 @@ pub struct PyBinModifier {
     matching: Option<PyLabelModifier>,
     #[pyo3(get, set)]
     return_bool: bool,
+    #[pyo3(get, set)]
+    group_labels: Option<Vec<String>>,
 }
 
 #[pymethods]
 impl PyBinModifier {
     #[new]
-    #[pyo3(signature = (card, return_bool, matching=None))]
+    #[pyo3(signature = (card, return_bool, matching=None, group_labels=None))]
     fn new(
         card: PyVectorMatchCardinality,
         return_bool: bool,
         matching: Option<PyLabelModifier>,
+        group_labels: Option<Vec<String>>,
     ) -> Self {
         PyBinModifier {
             card,
             matching,
             return_bool,
+            group_labels,
         }
     }
 
@@ -316,6 +328,10 @@ impl PyBinModifier {
             PyVectorMatchCardinality::OneToMany => parts.push("group_right".to_string()),
             _ => {}
         }
+
+        if let Some(labels) = &self.group_labels {
+            parts.push(format!("({})", labels.join(", ")));
+        } 
 
         parts.join(" ")
     }

--- a/test_promql_parser.py
+++ b/test_promql_parser.py
@@ -5,6 +5,8 @@ l = 'prometheus_http_requests_total{code="200", job="prometheus"}'
 
 print(parse('min_over_time(rate(foo{bar="baz"}[2s])[5m:] @ 1603775091)[4m:3s]'))
 
+print(parse('a{} / ignoring (b) group_left (c) (d)'))
+
 print(parse('1'))
 
 print(parse('1 + 1'))


### PR DESCRIPTION
Fixes issue where labels after a group_left/group_right were dropped when converting to python representation & then to string.

https://github.com/messense/py-promql-parser/issues/33

Before changes, the new test prints:
a{} / ignoring (b) group_left (d{})
After changes:
a{} / ignoring (b) group_left (c) (d{})